### PR TITLE
Add problemdetails.Problem

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 graft docs
+include example.py
 include LICENSE.txt
 include tests.py

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,9 @@ RFC-7807 implementation for Tornado
 |build| |coverage| |docs| |download| |license| |source|
 
 This library provides a version of ``tornado.web.RequestHandler.send_error``
-that speaks ``application/problem+json`` instead of HTML.
+that speaks ``application/problem+json`` instead of HTML.  The easiest
+way to use this library is to inherit from ``problemdetails.ErrorWriter``
+and call ``send_error()`` with additional parameters.
 
 .. code-block:: python
 
@@ -28,6 +30,26 @@ that speaks ``application/problem+json`` instead of HTML.
       "type": "https://tools.ietf.org/html/rfc7231#section-6.6.1"
    }
 
+As an alternative, you can raise a ``problemdetails.Problem`` instance and let
+the Tornado exception handling take care of eventually calling ``write_error``.
+The following snippet produces the same output as the previous example.
+
+.. code-block:: python
+
+   from tornado import web
+   import problemdetails
+
+
+   class MyHandler(problemdetails.ErrorWriter, web.RequestHandler):
+      def get(self):
+         if not self.do_something_hard():
+            raise problemdetails.Problem(status_code=500,
+                                         title='Failed to do_something_hard')
+
+The ``problemdetails.Problem`` instance passes all of the keyword parameters
+through in the resulting message so it is very easy to add fields.  The
+interface of ``tornado.web.RequestHandler.send_error`` is less expressive
+since keyword parameters may be swallowed by intervening code.
 
 .. |build| image:: https://img.shields.io/circleci/project/github/dave-shawley/tornado-problem-details/master.svg?style=social
    :target: https://circleci.com/gh/dave-shawley/tornado-problem-details/tree/master

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,6 +5,9 @@ Reference
 .. autoclass:: problemdetails.ErrorWriter
    :members:
 
+.. autoclass:: problemdetails.Problem
+   :members:
+
 .. data:: problemdetails.type_link_map
 
    Mapping of HTTP status code to *type* link.
@@ -17,6 +20,10 @@ Reference
 
 Release History
 ===============
+
+Next Release
+------------
+- Add :exc:`problemdetails.Problem`
 
 `0.0.1`_ (31 Mar 2019)
 ----------------------

--- a/example.py
+++ b/example.py
@@ -1,0 +1,38 @@
+import json
+import logging
+import os
+
+from tornado import gen, httpclient, ioloop, web
+import problemdetails
+
+
+class HttpBinHandler(problemdetails.ErrorWriter, web.RequestHandler):
+    @gen.coroutine
+    def get(self):
+        logger = logging.getLogger('HttpBinHandler')
+        url = 'http://httpbin.org/status/{0}'.format(
+            self.get_query_argument('status', '500'))
+        logger.info('retrieving %s', url)
+
+        client = httpclient.AsyncHTTPClient()
+        try:
+            response = yield client.fetch(url)
+            self.add_header('Content-Type', 'application/json')
+            self.write(response.body)
+        except httpclient.HTTPError as error:
+            logger.info('response %r', error.response)
+            raise problemdetails.Problem(
+                status_code=error.code,
+                httpbin_headers=dict(error.response.headers.items()))
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG,
+                        format='%(levelname)1.1s - %(name)s: %(message)s')
+    app = web.Application([web.url('/', HttpBinHandler)], debug=True)
+    app.listen(int(os.environ.get('PORT', '8000')))
+    iol = ioloop.IOLoop.current()
+    try:
+        iol.start()
+    except KeyboardInterrupt:
+        iol.stop()

--- a/problemdetails/__init__.py
+++ b/problemdetails/__init__.py
@@ -1,4 +1,5 @@
 try:
+    from problemdetails.errors import Problem
     from problemdetails.handlers import ErrorWriter, type_link_map
 except ImportError as error:  # pragma: no cover # noqa: 841
 
@@ -6,8 +7,14 @@ except ImportError as error:  # pragma: no cover # noqa: 841
         def __init__(self, *args, **kwargs):
             raise error  # noqa: 821
 
+    class Problem(Exception):
+        def __init__(self, *args, **kwargs):
+            raise error  # noqa: 821
 
-__all__ = ['ErrorWriter', 'type_link_map', 'version_info', 'version']
+
+__all__ = [
+    'ErrorWriter', 'Problem', 'type_link_map', 'version_info', 'version'
+]
 
 version_info = (0, 0, 1)
 version = '.'.join(str(c) for c in version_info)

--- a/problemdetails/errors.py
+++ b/problemdetails/errors.py
@@ -1,0 +1,27 @@
+from tornado import web
+
+
+class Problem(web.HTTPError):
+    """An exception that will be translated into a json document.
+
+    :param int status_code: HTTP status code to return
+    :param kwargs: additional keyword parameters are included in
+        the response document
+
+    :meth:`problemdetails.ErrorWriter.write_error` recognizes this
+    exception type and renders :attr:`.document` as the *problem+json*
+    result.  The *status* property is set to `status_code` and the
+    *type* property will be set by ``write_error`` unless it is
+    explicitly set.
+
+    .. attribute:: document
+
+       The keyword parameters are collected into this :class:`dict`
+       and rendered as the response document
+
+    """
+
+    def __init__(self, status_code, *args, **kwargs):
+        super().__init__(status_code, *args, **kwargs)
+        self.document = kwargs
+        self.document['status'] = status_code


### PR DESCRIPTION
This PR adds a `tornado.web.HTTPError` sub-class that `ErrorWriter.write_error` recognizes and formats as a problem-details document.