### PR TITLE
Promote to production

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,12 +1,13 @@
 Release History
 ===============
 
-`Next Release`_
----------------
+`1.0.0`_ (2 Jul 2022)
+---------------------
 - Renamed primary branch to "main"
 - Drop Python 2.7 support
 - Add type annotations
 - Rewrite examples to use asyncio instead of the Tornado IOLoop
+- Drop support for older Tornado versions (6.0+ is required now)
 
 `0.0.6`_ (8 Apr 2019)
 ---------------------
@@ -29,7 +30,8 @@ Release History
 ----------------------
 - Initial alpha release containing a very simple implementation.
 
-.. _Next Release: https://github.com/dave-shawley/tornado-problem-details/compare/0.0.6...main
+.. _Next Release: https://github.com/dave-shawley/tornado-problem-details/compare/1.0.0...main
+.. _1.0.0: https://github.com/dave-shawley/tornado-problem-details/compare/0.0.6...1.0.0
 .. _0.0.6: https://github.com/dave-shawley/tornado-problem-details/compare/0.0.5...0.0.6
 .. _0.0.5: https://github.com/dave-shawley/tornado-problem-details/compare/0.0.4...0.0.5
 .. _0.0.4: https://github.com/dave-shawley/tornado-problem-details/compare/0.0.2...0.0.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = tornado-problem-details
-version = 0.0.6.dev1
+version = 1.0.0
 description = RFC-7807 Error Documents for Tornado
 long_description = file:README.rst
 long_description_content_type = text/x-rst
@@ -9,11 +9,14 @@ author = Dave Shawley
 author_email = daveshawley@gmail.com
 license = BSD 3-Clause
 classifiers =
-    Development Status :: 3 - Alpha
+    Development Status :: 5 - Production/Stable
     Environment :: Web Environment
     Intended Audience :: Developers
     License :: OSI Approved :: BSD License
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Internet :: WWW/HTTP :: HTTP Servers
     Topic :: Software Development :: Libraries
     Typing :: Typed


### PR DESCRIPTION
This has been in production use for three years now so bumping to version 1.0.0 sounds like a good idea.  The API is stable as is the codebase.